### PR TITLE
feat: use external face matcher

### DIFF
--- a/.env
+++ b/.env
@@ -13,4 +13,5 @@ CONNECT_TO_MEDIASOUP_SERVER_PATH = "/join-call"
 USE_MEDIASOUP_ICE_RELAY = false
 REACT_BUILD_PATH = "./public/reactbuild/"
 EXPOSE_WEB_SERVER = false
+VISION_MATCHER_BASE_URL="http://localhost:5123"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,10 +37,6 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-RUN wget https://github.com/serengil/deepface_models/releases/download/v1.0/vgg_face_weights.h5
-RUN mkdir -p `dirname /root/.deepface/weights/vgg_face_weights.h5` 
-RUN mv vgg_face_weights.h5 /root/.deepface/weights/vgg_face_weights.h5
-
 # Install react front
 # RUN chmod +x pull.sh
 # RUN ./pull.sh

--- a/WebRTCPeer.py
+++ b/WebRTCPeer.py
@@ -31,17 +31,18 @@ class VideoTransformTrack(MediaStreamTrack):
 
     kind = "video"
 
-    def __init__(self, asyncio_loop, verification_token, rd, d, q, lang, number_of_gestures_to_request, track):
+    def __init__(self, asyncio_loop, verification_token, rd, d, q, lang, number_of_gestures_to_request, vision_matcher_base_url, track):
         super().__init__()
         self.track = track
         self.livenessProcessor = LivenessDetector(
-            asyncio_loop, 
-            verification_token,
-            rd,
-            d,
-            q,
-            lang, 
-            number_of_gestures_to_request
+            asyncio_loop=asyncio_loop, 
+            verification_token=verification_token,
+            rd=rd,
+            d=d,
+            q=q,
+            lang=lang, 
+            number_of_gestures_to_request=number_of_gestures_to_request,
+            vision_matcher_base_url=vision_matcher_base_url
         )
 
     def cleanup(self):
@@ -70,8 +71,9 @@ class VideoTransformTrack(MediaStreamTrack):
 def log_info(xsource, msg, *args):
     logger.info(xsource + " " + msg, *args)
 
-async def offer(asyncio_loop, number_of_gestures_to_request, request):
+async def offer(asyncio_loop, number_of_gestures_to_request, vision_matcher_base_url, request):
     params = await request.json()
+    logger.debug(f"offer params: {params}")
     offer = RTCSessionDescription(sdp=params["sdp"], type=params["type"])
     logger.debug("!! Verification token: %s", params.get("token"))
     verification_token = params.get("token")
@@ -112,6 +114,7 @@ async def offer(asyncio_loop, number_of_gestures_to_request, request):
                 q,
                 lang,
                 number_of_gestures_to_request,
+                vision_matcher_base_url,
                 relay.subscribe(track)
             )
 

--- a/main.py
+++ b/main.py
@@ -71,6 +71,8 @@ if __name__ == "__main__":
     expose_web_server_str = os.environ.get("EXPOSE_WEB_SERVER", "true")
     expose_web_server = bool(strtobool(expose_web_server_str))
     logging.info("expose_web_server: %s", expose_web_server_str)
+    vision_matcher_base_url = os.environ.get("VISION_MATCHER_BASE_URL", "http://localhost:5123")
+    logging.info("vision_matcher_base_url: %s", vision_matcher_base_url)
     logging.info("Using React build: %s", use_react_build)
     react_build_path = os.environ.get("REACT_BUILD_PATH", "./public/")
     logging.info("React build path: %s", react_build_path)
@@ -84,9 +86,9 @@ if __name__ == "__main__":
     asyncio_loop = asyncio.get_event_loop()
     logging.info("Asyncio loop: %s", asyncio_loop)
     # Pass the environment variable to the offer function when invoked by aiohttp
-    app.router.add_post(offer_path, partial(offer, asyncio_loop, number_of_gestures_to_request))
+    app.router.add_post(offer_path, partial(offer, asyncio_loop, number_of_gestures_to_request, vision_matcher_base_url))
     #app.router.add_post(picture_path, picture)
-    app.router.add_post(connect_to_mediasoup_path, connectToMediasoupServer)
+    app.router.add_post(connect_to_mediasoup_path, partial(connectToMediasoupServer, vision_matcher_base_url))
     app.router.add_get(requester_status_path, get_gestures_requester_process_status)
 
 


### PR DESCRIPTION
Initial work on making Vision Service image smaller. Here we remove the DepeFace direct dependency on the Liveness Detector by calling an external `vision-matcher` instance's `face_match` endpoint. However, we still require deepface due to the Liveness Detector's face finding algorithm (this will be solved in #1).